### PR TITLE
Update `storage::logging` sub-module

### DIFF
--- a/src/action/routine.rs
+++ b/src/action/routine.rs
@@ -87,7 +87,7 @@ impl Routine {
             match result {
                 Ok(event) => {
                     let event = event.unwrap();
-                    let _ = self.add_to_log(event);
+                    let _ = self.push_to_log(event);
                     return true;
                 }
                 Err(e) => {

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -105,7 +105,7 @@ impl GenericInput {
 
         self.propagate(&event);
 
-        self.add_to_log(event);
+        self.push_to_log(event);
 
         Ok(event)
     }

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -97,7 +97,7 @@ impl GenericOutput {
         // update cached state
         self.state = Some(event.data.value);
 
-        self.add_to_log(event);
+        self.push_to_log(event);
 
         Ok(event)
     }

--- a/src/storage/logging/chronicle.rs
+++ b/src/storage/logging/chronicle.rs
@@ -13,7 +13,7 @@ pub trait Chronicle {
         if let Some(log) = self.log() {
             log.try_lock()
                 .unwrap()
-                .push(event.timestamp, event)
+                .push(event)
                 .expect("Unknown error when adding event to log");
         }
     }

--- a/src/storage/logging/chronicle.rs
+++ b/src/storage/logging/chronicle.rs
@@ -21,7 +21,7 @@ pub trait Chronicle {
     ///
     /// - If underlying [`std::sync::Arc`] reference is poisoned and cannot be locked.
     /// - When an error occurs during [`Log::push()`]
-    fn add_to_log(&self, event: IOEvent) {
+    fn push_to_log(&self, event: IOEvent) {
         if let Some(log) = self.log() {
             log.try_lock()
                 .unwrap()

--- a/src/storage/logging/chronicle.rs
+++ b/src/storage/logging/chronicle.rs
@@ -2,13 +2,25 @@ use crate::helpers::Def;
 use crate::io::IOEvent;
 use crate::storage::Log;
 
-/// Transparently enables a reference to `Log` to be shared.
+/// Interface for interacting with [`Log`] behind a [`Def`] guard.
 pub trait Chronicle {
     /// Property to return reference to field
     ///
-    /// Upgrading of `Weak` reference should occur here
+    /// # Panics
+    ///
+    /// If stored reference to `Log` is [`std::sync::Weak`] and cannot be upgraded.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` with `Some` a [`Log`] is assigned, otherwise `None`.
     fn log(&self) -> Option<Def<Log>>;
 
+    /// Appends [`IOEvent`] to collection
+    ///
+    /// # Panics
+    ///
+    /// - If underlying [`std::sync::Arc`] reference is poisoned and cannot be locked.
+    /// - When an error occurs during [`Log::push()`]
     fn add_to_log(&self, event: IOEvent) {
         if let Some(log) = self.log() {
             log.try_lock()
@@ -18,6 +30,14 @@ pub trait Chronicle {
         }
     }
 
+    /// Simple check to see if a [`Log`] is assigned or not
+    ///
+    /// Underlying reference is not checked or validated.
+    ///
+    /// # Returns
+    ///
+    /// - `true`: when log is assigned
+    /// - `false`: when log is `None`
     fn has_log(&self) -> bool {
         match self.log() {
             Some(_) => true,

--- a/src/storage/logging/chronicle.rs
+++ b/src/storage/logging/chronicle.rs
@@ -1,0 +1,27 @@
+use crate::helpers::Def;
+use crate::io::IOEvent;
+use crate::storage::Log;
+
+/// Transparently enables a reference to `Log` to be shared.
+pub trait Chronicle {
+    /// Property to return reference to field
+    ///
+    /// Upgrading of `Weak` reference should occur here
+    fn log(&self) -> Option<Def<Log>>;
+
+    fn add_to_log(&self, event: IOEvent) {
+        if let Some(log) = self.log() {
+            log.try_lock()
+                .unwrap()
+                .push(event.timestamp, event)
+                .expect("Unknown error when adding event to log");
+        }
+    }
+
+    fn has_log(&self) -> bool {
+        match self.log() {
+            Some(_) => true,
+            None => false,
+        }
+    }
+}

--- a/src/storage/logging/log.rs
+++ b/src/storage/logging/log.rs
@@ -82,10 +82,9 @@ impl Log {
 
     pub fn push(
         &mut self,
-        timestamp: DateTime<Utc>,
         event: IOEvent,
     ) -> Result<&mut IOEvent, ErrorType> {
-        match self.log.entry(timestamp) {
+        match self.log.entry(event.timestamp) {
             Entry::Occupied(_) => Err(Error::new(ErrorKind::ContainerError, "Key already exists")),
             Entry::Vacant(entry) => Ok(entry.insert(event)),
         }
@@ -158,7 +157,7 @@ mod tests {
                 DeviceType::Input(inner) => inner.generate_event(RawValue::default()),
                 DeviceType::Output(inner) => inner.generate_event(RawValue::default()),
             };
-            log.lock().unwrap().push(event.timestamp, event).unwrap();
+            log.lock().unwrap().push(event).unwrap();
             thread::sleep(Duration::from_nanos(1)); // add delay so that we don't finish too quickly
         }
     }

--- a/src/storage/logging/mod.rs
+++ b/src/storage/logging/mod.rs
@@ -1,0 +1,7 @@
+mod chronicle;
+mod log;
+mod types;
+
+pub use chronicle::Chronicle;
+pub use log::*;
+pub use types::*;

--- a/src/storage/logging/types.rs
+++ b/src/storage/logging/types.rs
@@ -4,8 +4,12 @@ use crate::storage::Log;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
-/// Hashmap type alias defines a type alias `LogType` for storing `IOEvent` by `DateTime<Utc>` keys.
+/// Mapped collection for storing [`IOEvent`]s by [`DateTime<Utc>`] keys
+///
+/// All events should originate from a single source.
 pub type EventCollection = HashMap<DateTime<Utc>, IOEvent>;
 
-/// Primary container for storing `Log` instances.
+/// Primary container for storing multiple [`Log`] instances
+///
+/// [`Log`] instances may belong to a single source or multiple sources.
 pub type LogContainer = Vec<Def<Log>>;

--- a/src/storage/logging/types.rs
+++ b/src/storage/logging/types.rs
@@ -1,0 +1,11 @@
+use crate::helpers::Def;
+use crate::io::IOEvent;
+use crate::storage::Log;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+/// Hashmap type alias defines a type alias `LogType` for storing `IOEvent` by `DateTime<Utc>` keys.
+pub type EventCollection = HashMap<DateTime<Utc>, IOEvent>;
+
+/// Primary container for storing `Log` instances.
+pub type LogContainer = Vec<Def<Log>>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,4 +6,4 @@ mod persistent;
 
 pub use grouping::Group;
 pub use logging::*;
-pub use persistent::Persistent;
+pub use persistent::{Persistent, FILETYPE};

--- a/src/storage/persistent.rs
+++ b/src/storage/persistent.rs
@@ -1,5 +1,10 @@
 use crate::errors::ErrorType;
 
+/// Default filetype suffix.
+///
+/// Used by [`Log::filename()`]
+pub const FILETYPE: &str = ".json";
+
 /// Expresses an interface to save or load from disk
 pub trait Persistent {
     /// save data to disk


### PR DESCRIPTION
# Changelist
- Refactor `Chronicle`, `Log` and type aliases into multiple sub-modules as per #100
- Proper documentation for `Chronicle`
- Proper documentation for `Log`
- Rename `LogType` alias to `EventCollection`
- Moves location of `FILETYPE` suffix constant to `persistent` sub-module
- Refactors `Chronicle::add_to_log()` to `Chronicle::push_to_log()`
- Removes the `timestamp` parameter from `Log::push()`