### PR TITLE
Update device

### DIFF
--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -50,7 +50,7 @@ fn setup_devices(poller: &mut Group) {
         Input::new(
             "Mock Output",
             OUTPUT_ID,
-            Some(IOKind::Light),
+            IOKind::Light,
         ).set_command(
             IOCommand::Output(|val| Ok(println!("\n{}\n", val)))
         )

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -87,7 +87,7 @@ fn main() {
             ).set_command(
                 command
             ).init_log(
-                Some(poller.settings())
+                poller.settings()
             ).init_publisher();
 
         // setup publisher/action
@@ -116,7 +116,7 @@ fn main() {
             kind,
         )
             .set_command(command)
-            .init_log(Some(poller.settings()))
+            .init_log(poller.settings())
             .init_publisher();
 
         // setup publisher/action

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -113,7 +113,7 @@ fn main() {
         let mut input = Input::new(
             name,
             id,
-            Some(kind),
+            kind,
         )
             .set_command(command)
             .init_log(Some(poller.settings()))

--- a/examples/thermostat.rs
+++ b/examples/thermostat.rs
@@ -108,7 +108,7 @@ fn main() {
             Input::new(
                 "mock temp sensor",
                 INPUT_ID,
-                Some(IOKind::Temperature),
+                IOKind::Temperature,
             ).set_command(
                 IOCommand::Input(|| EXTERNAL_VALUE)
             ).init_log(None)
@@ -120,7 +120,7 @@ fn main() {
         Output::new(
             "test mock cooling device",
             OUTPUT_ID,
-            Some(IOKind::Temperature),
+            IOKind::Temperature,
         ).set_command(
             IOCommand::Output(|val| Ok(println!("\nSimulated HW Output: {}\n", val)))
         ).init_log(None)

--- a/src/io/device.rs
+++ b/src/io/device.rs
@@ -17,7 +17,7 @@ pub type DeviceContainer<K, D> = HashMap<K, Def<D>>;
 /// Additionally, an accessor, `metadata()` is defined to provide for the facade methods to access
 /// device name, id, direction, and kind. Therefore, implementing structs shall implement a field
 /// `metadata` that is mutably accessed through the reciprocal getter method.
-pub trait Device: Chronicle {
+pub trait Device: Chronicle + DeviceGetters {
     /// Creates a new instance of the device with the given parameters.
     ///
     /// # Parameters
@@ -31,35 +31,12 @@ pub trait Device: Chronicle {
         N: Into<String>,
         K: Into<Option<IOKind>>;
 
-    /// Returns a reference to the device's metadata
-    /// from which information such as name, ID, kind, and I/O direction are inferred.
-    fn metadata(&self) -> &DeviceMetadata;
-
-    /// Returns the name of the device.
-    fn name(&self) -> String {
-        self.metadata().name.clone()
-    }
-
     fn set_name<N>(&mut self, name: N)
     where
         N: Into<String>;
 
-    /// Returns the ID of the device.
-    fn id(&self) -> IdType {
-        self.metadata().id
-    }
 
     fn set_id(&mut self, id: IdType);
-
-    /// Returns the I/O direction of the device.
-    fn direction(&self) -> IODirection {
-        self.metadata().direction
-    }
-
-    /// Returns the type of device as `IOKind`.
-    fn kind(&self) -> IOKind {
-        self.metadata().kind
-    }
 
     /// Generate an `IOEvent` instance from provided value
     ///
@@ -97,9 +74,6 @@ pub trait Device: Chronicle {
         self
     }
 
-    /// Immutable reference to cached state
-    fn state(&self) -> &Option<RawValue>;
-
     fn into_deferred(self) -> Def<Self>
     where
         Self: Sized
@@ -108,3 +82,46 @@ pub trait Device: Chronicle {
     }
 }
 
+pub trait DeviceGetters {
+    /// Reference to device metadata
+    ///
+    /// Information such as `name`, `id`, `kind`, and `direction` are taken from metadata.
+    ///
+    /// # Returns
+    ///
+    /// An immutable reference to internal device metadata
+    ///
+    /// # See Also
+    ///
+    /// - [`DeviceMetadata`]
+    fn metadata(&self) -> &DeviceMetadata;
+
+    /// Returns the name of the device.
+    fn name(&self) -> String {
+        self.metadata().name.clone()
+    }
+
+    /// Returns the ID of the device.
+    fn id(&self) -> IdType {
+        self.metadata().id
+    }
+
+    /// Returns the I/O direction of the device.
+    fn direction(&self) -> IODirection {
+        self.metadata().direction
+    }
+
+    /// Returns the type of device as `IOKind`.
+    fn kind(&self) -> IOKind {
+        self.metadata().kind
+    }
+
+    /// Immutable reference to cached state
+    ///
+    /// # Returns
+    ///
+    /// An `Option` that is:
+    /// - `None` upon initialization since device has not been read from or written to.
+    /// - `RawValue` after first read or write, and represents last known state.
+    fn state(&self) -> &Option<RawValue>;
+}

--- a/src/io/device.rs
+++ b/src/io/device.rs
@@ -39,10 +39,16 @@ pub trait Device: Chronicle {
         self.metadata().name.clone()
     }
 
+    fn set_name<N>(&mut self, name: N)
+    where
+        N: Into<String>;
+
     /// Returns the ID of the device.
     fn id(&self) -> IdType {
         self.metadata().id
     }
+
+    fn set_id(&mut self, id: IdType);
 
     /// Returns the I/O direction of the device.
     fn direction(&self) -> IODirection {

--- a/src/io/device.rs
+++ b/src/io/device.rs
@@ -25,10 +25,11 @@ pub trait Device: Chronicle {
     /// `id`: device ID.
     /// `kind`: kind of I/O device. Optional argument.
     /// `log`: Optional deferred owned log for the device.
-    fn new<N>(name: N, id: IdType, kind: Option<IOKind>) -> Self
+    fn new<N, K>(name: N, id: IdType, kind: K) -> Self
     where
         Self: Sized,
-        N: Into<String>;
+        N: Into<String>,
+        K: Into<Option<IOKind>>;
 
     /// Returns a reference to the device's metadata
     /// from which information such as name, ID, kind, and I/O direction are inferred.

--- a/src/io/device.rs
+++ b/src/io/device.rs
@@ -87,9 +87,10 @@ pub trait Device: Chronicle {
     fn set_log(&mut self, log: Def<Log>);
 
     /// Initialize, set, and return log.
-    fn init_log(mut self, settings: Option<Arc<Settings>>) -> Self
+    fn init_log<S>(mut self, settings: S) -> Self
     where
         Self: Sized,
+        S: Into<Option<Arc<Settings>>>,
     {
         let log = Def::new(Log::new(&self.metadata(), settings));
         self.set_log(log);

--- a/src/io/device.rs
+++ b/src/io/device.rs
@@ -17,7 +17,7 @@ pub type DeviceContainer<K, D> = HashMap<K, Def<D>>;
 /// Additionally, an accessor, `metadata()` is defined to provide for the facade methods to access
 /// device name, id, direction, and kind. Therefore, implementing structs shall implement a field
 /// `metadata` that is mutably accessed through the reciprocal getter method.
-pub trait Device: Chronicle + DeviceGetters {
+pub trait Device: Chronicle + DeviceGetters + DeviceSetters {
     /// Creates a new instance of the device with the given parameters.
     ///
     /// # Parameters
@@ -30,13 +30,6 @@ pub trait Device: Chronicle + DeviceGetters {
         Self: Sized,
         N: Into<String>,
         K: Into<Option<IOKind>>;
-
-    fn set_name<N>(&mut self, name: N)
-    where
-        N: Into<String>;
-
-
-    fn set_id(&mut self, id: IdType);
 
     /// Generate an `IOEvent` instance from provided value
     ///
@@ -55,13 +48,19 @@ pub trait Device: Chronicle + DeviceGetters {
         IOEvent::new(self.metadata(), dt, value)
     }
 
-    /// Setter for `command` field
+    /// Setter for `command` field as builder method
+    ///
+    /// # Notes
+    ///
+    /// Since this function is a builder command, and is meant to be used with method chaining,
+    /// it is not included in [`DeviceSetters`]
+    ///
+    /// # Returns
+    ///
+    /// Passes ownership of `self`
     fn set_command(self, command: IOCommand) -> Self
     where
         Self: Sized;
-
-    /// Setter for `log` field
-    fn set_log(&mut self, log: Def<Log>);
 
     /// Initialize, set, and return log.
     fn init_log<S>(mut self, settings: S) -> Self
@@ -124,4 +123,15 @@ pub trait DeviceGetters {
     /// - `None` upon initialization since device has not been read from or written to.
     /// - `RawValue` after first read or write, and represents last known state.
     fn state(&self) -> &Option<RawValue>;
+}
+
+pub trait DeviceSetters {
+    fn set_name<N>(&mut self, name: N)
+        where
+            N: Into<String>;
+
+    fn set_id(&mut self, id: IdType);
+
+    /// Setter for `log` field
+    fn set_log(&mut self, log: Def<Log>);
 }

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -50,6 +50,14 @@ impl Device for Input {
         &self.metadata
     }
 
+    fn set_name<N>(&mut self, name: N) where N: Into<String> {
+        self.metadata.name = name.into();
+    }
+
+    fn set_id(&mut self, id: IdType) {
+        self.metadata.id = id;
+    }
+
     fn set_command(mut self, command: IOCommand) -> Self
     where
         Self: Sized,

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -23,12 +23,13 @@ impl Device for Input {
     /// * `id`: arbitrary, numeric ID to differentiate from other sensors
     ///
     /// returns: MockPhSensor
-    fn new<N>(name: N, id: IdType, kind: Option<IOKind>) -> Self
+    fn new<N, K>(name: N, id: IdType, kind: K) -> Self
     where
         Self: Sized,
-        N: Into<String>
+        N: Into<String>,
+        K: Into<Option<IOKind>>,
     {
-        let kind = kind.unwrap_or_default();
+        let kind = kind.into().unwrap_or_default();
 
         let metadata: DeviceMetadata = DeviceMetadata::new(name.into(), id, kind, IODirection::In);
 
@@ -159,7 +160,7 @@ impl Chronicle for Input {
 #[cfg(test)]
 mod tests {
     use crate::action::{IOCommand};
-    use crate::io::{Device, Input, RawValue};
+    use crate::io::{Device, Input, IOKind, RawValue};
     use crate::storage::Chronicle;
 
     const DUMMY_OUTPUT: RawValue = RawValue::Float(1.2);
@@ -170,6 +171,13 @@ mod tests {
     fn new_name_parameter() {
         Input::new("as &str", 0, None);
         Input::new(String::from("as String"), 0, None);
+    }
+
+    #[test]
+    fn new_kind_parameter() {
+        Input::new("", 0, None);
+        Input::new("", 0, Some(IOKind::Unassigned));
+        Input::new("", 0, IOKind::Unassigned);
     }
 
     #[test]

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use crate::action::{Command, IOCommand, Publisher};
 use crate::errors::{ErrorType, no_internal_closure};
 use crate::helpers::Def;
-use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue};
+use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters};
 use crate::storage::{Chronicle, Log};
 
 #[derive(Default)]
@@ -47,10 +47,6 @@ impl Device for Input {
         }
     }
 
-    fn metadata(&self) -> &DeviceMetadata {
-        &self.metadata
-    }
-
     fn set_name<N>(&mut self, name: N) where N: Into<String> {
         self.metadata.name = name.into();
     }
@@ -71,6 +67,12 @@ impl Device for Input {
 
     fn set_log(&mut self, log: Def<Log>) {
         self.log = Some(log);
+    }
+}
+
+impl DeviceGetters for Input {
+    fn metadata(&self) -> &DeviceMetadata {
+        &self.metadata
     }
 
     /// Immutable reference to cached state
@@ -161,7 +163,7 @@ impl Chronicle for Input {
 mod tests {
     use std::sync::Arc;
     use crate::action::{IOCommand};
-    use crate::io::{Device, Input, IOKind, RawValue};
+    use crate::io::{Device, DeviceGetters, Input, IOKind, RawValue};
     use crate::settings::Settings;
     use crate::storage::Chronicle;
 

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use crate::action::{Command, IOCommand, Publisher};
 use crate::errors::{ErrorType, no_internal_closure};
 use crate::helpers::Def;
-use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters};
+use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters, DeviceSetters};
 use crate::storage::{Chronicle, Log};
 
 #[derive(Default)]
@@ -47,14 +47,6 @@ impl Device for Input {
         }
     }
 
-    fn set_name<N>(&mut self, name: N) where N: Into<String> {
-        self.metadata.name = name.into();
-    }
-
-    fn set_id(&mut self, id: IdType) {
-        self.metadata.id = id;
-    }
-
     fn set_command(mut self, command: IOCommand) -> Self
     where
         Self: Sized,
@@ -63,10 +55,6 @@ impl Device for Input {
             .expect("Command is not input");
         self.command = Some(command);
         self
-    }
-
-    fn set_log(&mut self, log: Def<Log>) {
-        self.log = Some(log);
     }
 }
 
@@ -80,6 +68,20 @@ impl DeviceGetters for Input {
     /// `state` field should be updated by `write()`
     fn state(&self) -> &Option<RawValue> {
         &self.state
+    }
+}
+
+impl DeviceSetters for Input {
+    fn set_name<N>(&mut self, name: N) where N: Into<String> {
+        self.metadata.name = name.into();
+    }
+
+    fn set_id(&mut self, id: IdType) {
+        self.metadata.id = id;
+    }
+
+    fn set_log(&mut self, log: Def<Log>) {
+        self.log = Some(log);
     }
 }
 

--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -159,8 +159,10 @@ impl Chronicle for Input {
 // Testing
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use crate::action::{IOCommand};
     use crate::io::{Device, Input, IOKind, RawValue};
+    use crate::settings::Settings;
     use crate::storage::Chronicle;
 
     const DUMMY_OUTPUT: RawValue = RawValue::Float(1.2);
@@ -221,13 +223,38 @@ mod tests {
 
     #[test]
     fn test_init_log() {
-        let mut input = Input::default();
+        // test w/ None
+        {
+            let mut input = Input::default();
 
-        assert_eq!(false, input.has_log());
+            assert_eq!(false, input.has_log());
 
-        input = input.init_log(None);
+            input = input.init_log(None);
 
-        assert_eq!(true, input.has_log());
+            assert_eq!(true, input.has_log());
+        }
+
+        // test `Into<_>` conversion
+        {
+            let mut input = Input::default();
+
+            assert_eq!(false, input.has_log());
+
+            input = input.init_log(Arc::new(Settings::default()));
+
+            assert_eq!(true, input.has_log());
+        }
+
+        // test wrapping in `Some(_)`
+        {
+            let mut input = Input::default();
+
+            assert_eq!(false, input.has_log());
+
+            input = input.init_log(Some(Arc::new(Settings::default())));
+
+            assert_eq!(true, input.has_log());
+        }
     }
 }
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use crate::action::{Command, IOCommand};
 use crate::errors::{ErrorType, no_internal_closure};
 use crate::helpers::Def;
-use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters};
+use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters, DeviceSetters};
 use crate::storage::{Chronicle, Log};
 
 #[derive(Default)]
@@ -24,6 +24,20 @@ impl DeviceGetters for Output {
     /// `state` field should be updated by `write()`
     fn state(&self) -> &Option<RawValue> {
         &self.state
+    }
+}
+
+impl DeviceSetters for Output {
+    fn set_name<N>(&mut self, name: N) where N: Into<String> {
+        self.metadata.name = name.into();
+    }
+
+    fn set_id(&mut self, id: IdType) {
+        self.metadata.id = id;
+    }
+
+    fn set_log(&mut self, log: Def<Log>) {
+        self.log = Some(log);
     }
 }
 
@@ -58,14 +72,6 @@ impl Device for Output {
         }
     }
 
-    fn set_name<N>(&mut self, name: N) where N: Into<String> {
-        self.metadata.name = name.into();
-    }
-
-    fn set_id(&mut self, id: IdType) {
-        self.metadata.id = id;
-    }
-
     fn set_command(mut self, command: IOCommand) -> Self
     where
         Self: Sized,
@@ -74,10 +80,6 @@ impl Device for Output {
             .expect("Command is not output");
         self.command = Some(command);
         self
-    }
-
-    fn set_log(&mut self, log: Def<Log>) {
-        self.log = Some(log)
     }
 }
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -117,8 +117,10 @@ impl Chronicle for Output {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use crate::action::IOCommand;
     use crate::io::{Device, IOKind, Output, RawValue};
+    use crate::settings::Settings;
     use crate::storage::Chronicle;
 
     /// Dummy output command for testing.
@@ -180,6 +182,43 @@ mod tests {
 
         // assert that event was added to log
         assert_eq!(log.try_lock().unwrap().iter().count(), 1);
+    }
+
+
+    #[test]
+    fn test_init_log() {
+        // test w/ None
+        {
+            let mut output = Output::default();
+
+            assert_eq!(false, output.has_log());
+
+            output = output.init_log(None);
+
+            assert_eq!(true, output.has_log());
+        }
+
+        // test `Into<_>` conversion
+        {
+            let mut output = Output::default();
+
+            assert_eq!(false, output.has_log());
+
+            output = output.init_log(Arc::new(Settings::default()));
+
+            assert_eq!(true, output.has_log());
+        }
+
+        // test wrapping in `Some(_)`
+        {
+            let mut output = Output::default();
+
+            assert_eq!(false, output.has_log());
+
+            output = output.init_log(Some(Arc::new(Settings::default())));
+
+            assert_eq!(true, output.has_log());
+        }
     }
 }
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use crate::action::{Command, IOCommand};
 use crate::errors::{ErrorType, no_internal_closure};
 use crate::helpers::Def;
-use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue};
+use crate::io::{Device, DeviceMetadata, IODirection, IOEvent, IOKind, IdType, RawValue, DeviceGetters};
 use crate::storage::{Chronicle, Log};
 
 #[derive(Default)]
@@ -12,6 +12,19 @@ pub struct Output {
     state: Option<RawValue>,
     log: Option<Def<Log>>,
     command: Option<IOCommand>,
+}
+
+impl DeviceGetters for Output {
+    fn metadata(&self) -> &DeviceMetadata {
+        &self.metadata
+    }
+
+    /// Immutable reference to cached state
+    ///
+    /// `state` field should be updated by `write()`
+    fn state(&self) -> &Option<RawValue> {
+        &self.state
+    }
 }
 
 // Implement traits
@@ -45,10 +58,6 @@ impl Device for Output {
         }
     }
 
-    fn metadata(&self) -> &DeviceMetadata {
-        &self.metadata
-    }
-
     fn set_name<N>(&mut self, name: N) where N: Into<String> {
         self.metadata.name = name.into();
     }
@@ -69,13 +78,6 @@ impl Device for Output {
 
     fn set_log(&mut self, log: Def<Log>) {
         self.log = Some(log)
-    }
-
-    /// Immutable reference to cached state
-    ///
-    /// `state` field should be updated by `write()`
-    fn state(&self) -> &Option<RawValue> {
-        &self.state
     }
 }
 
@@ -119,7 +121,7 @@ impl Chronicle for Output {
 mod tests {
     use std::sync::Arc;
     use crate::action::IOCommand;
-    use crate::io::{Device, IOKind, Output, RawValue};
+    use crate::io::{Device, DeviceGetters, IOKind, Output, RawValue};
     use crate::settings::Settings;
     use crate::storage::Chronicle;
 

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -48,6 +48,14 @@ impl Device for Output {
         &self.metadata
     }
 
+    fn set_name<N>(&mut self, name: N) where N: Into<String> {
+        self.metadata.name = name.into();
+    }
+
+    fn set_id(&mut self, id: IdType) {
+        self.metadata.id = id;
+    }
+
     fn set_command(mut self, command: IOCommand) -> Self
     where
         Self: Sized,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -24,12 +24,13 @@ impl Device for Output {
     /// * `id`: arbitrary, numeric ID to differentiate from other devices
     ///
     /// returns: GenericOutput
-    fn new<N>(name: N, id: IdType, kind: Option<IOKind>) -> Self
+    fn new<N, K>(name: N, id: IdType, kind: K) -> Self
     where
         Self: Sized,
-        N: Into<String>
+        N: Into<String>,
+        K: Into<Option<IOKind>>,
     {
-        let kind = kind.unwrap_or_default();
+        let kind = kind.into().unwrap_or_default();
         let state = None;
         let metadata: DeviceMetadata = DeviceMetadata::new(name, id, kind, IODirection::Out);
 
@@ -117,7 +118,7 @@ impl Chronicle for Output {
 #[cfg(test)]
 mod tests {
     use crate::action::IOCommand;
-    use crate::io::{Device, Output, RawValue};
+    use crate::io::{Device, IOKind, Output, RawValue};
     use crate::storage::Chronicle;
 
     /// Dummy output command for testing.
@@ -129,6 +130,13 @@ mod tests {
     fn new_name_parameter() {
         Output::new("as &str", 0, None);
         Output::new(String::from("as String"), 0, None);
+    }
+
+    #[test]
+    fn new_kind_parameter() {
+        Output::new("", 0, None);
+        Output::new("", 0, Some(IOKind::Unassigned));
+        Output::new("", 0, IOKind::Unassigned);
     }
 
     #[test]

--- a/src/storage/grouping.rs
+++ b/src/storage/grouping.rs
@@ -1,10 +1,7 @@
 use std::collections::hash_map::Entry;
 use crate::errors::{Error, ErrorKind, ErrorType};
 use crate::helpers::{check_results, Def};
-use crate::io::{
-    Device, DeviceContainer, Input, Output, IOEvent,
-    IdType,
-};
+use crate::io::{Device, DeviceContainer, Input, Output, IOEvent, IdType, DeviceGetters};
 use crate::settings::Settings;
 use crate::storage::{Chronicle, Persistent};
 use chrono::{DateTime, Duration, Utc};

--- a/src/storage/logging/log.rs
+++ b/src/storage/logging/log.rs
@@ -259,7 +259,7 @@ mod tests {
         let filename;
         // test save
         {
-            let device = Input::new(String::from(SENSOR_NAME), ID, Some(IOKind::Flow))
+            let device = Input::new(String::from(SENSOR_NAME), ID, IOKind::Flow)
                 .set_command(COMMAND)
                 .init_log(None);
             let log = device.log().unwrap();
@@ -277,7 +277,7 @@ mod tests {
         // test load
         // build back up then load
         {
-            let device = Input::new(String::from(SENSOR_NAME), ID, Some(IOKind::Flow))
+            let device = Input::new(SENSOR_NAME, ID, IOKind::Flow)
                 .set_command(COMMAND)
                 .init_log(None);
             let log = device.log().unwrap();

--- a/src/storage/logging/log.rs
+++ b/src/storage/logging/log.rs
@@ -46,11 +46,14 @@ impl Log {
     /// # Returns
     ///
     /// Empty log with identity attributes belonging to given device.
-    pub fn new(metadata: &DeviceMetadata, settings: Option<Arc<Settings>>) -> Self {
+    pub fn new<S>(metadata: &DeviceMetadata, settings: S) -> Self
+    where
+        S: Into<Option<Arc<Settings>>>,
+    {
         let id = metadata.id;
         let name = metadata.name.clone();
         let log = EventCollection::default();
-        let settings = settings.unwrap_or_else(|| Arc::new(Settings::default()));
+        let settings = settings.into().unwrap_or_else(|| Arc::new(Settings::default()));
 
         Self {
             id,
@@ -229,11 +232,13 @@ impl Persistent for Log {
 mod tests {
     use crate::action::IOCommand;
     use crate::helpers::Def;
-    use crate::io::{Device, Input, IOKind, IdType, RawValue};
+    use crate::io::{Device, Input, IOKind, IdType, RawValue, DeviceMetadata};
     use crate::storage::{Chronicle, Log, Persistent};
     use std::path::Path;
     use std::time::Duration;
     use std::{fs, thread};
+    use std::sync::Arc;
+    use crate::settings::Settings;
 
     fn add_to_log<D>(device: &D, log: &Def<Log>, count: usize)
     where
@@ -244,6 +249,17 @@ mod tests {
             log.lock().unwrap().push(event).unwrap();
             thread::sleep(Duration::from_nanos(1)); // add delay so that we don't finish too quickly
         }
+    }
+
+    #[test]
+    /// Test that constructor `Into<_>` conversion works properly for `settings` parameter
+    fn constructor_settings_parameter() {
+        let metadata = DeviceMetadata::default();
+        let settings = Arc::new(Settings::default());
+
+        Log::new(&metadata, None);
+        Log::new(&metadata, Some(settings.clone()));
+        Log::new(&metadata, settings);
     }
 
     #[test]

--- a/tests/grouping_test.rs
+++ b/tests/grouping_test.rs
@@ -3,7 +3,7 @@ use chrono::Duration;
 use sensd::action::IOCommand;
 use sensd::io::{Device, Input, IOKind, Output, RawValue};
 use sensd::settings::Settings;
-use sensd::storage::Group;
+use sensd::storage::{Chronicle, Group};
 use std::sync::Arc;
 
 #[test]
@@ -74,7 +74,9 @@ fn test_poll() {
     // check that all logs are empty
     const COUNT: usize = 15;
     for iteration in 0..COUNT {
-        for log in group.logs.iter() {
+        for input in group.inputs.values() {
+            let binding = input.try_lock().unwrap();
+            let log = binding.log().unwrap();
             assert_eq!(log.lock().unwrap().iter().count(), iteration);
         }
 
@@ -85,7 +87,10 @@ fn test_poll() {
         ));
     }
 
-    for log in group.logs.iter() {
-        assert_eq!(COUNT, log.lock().unwrap().iter().count())
+    for input in group.inputs.values() {
+        let binding = input.try_lock().unwrap();
+        let log = binding.log().unwrap();
+
+        assert_eq!(COUNT, log.lock().unwrap().iter().count());
     }
 }

--- a/tests/grouping_test.rs
+++ b/tests/grouping_test.rs
@@ -17,19 +17,19 @@ fn test_builder_pattern() {
             Input::new(
                 "test name",
                 0,
-                Some(IOKind::PH),
+                IOKind::PH,
             ).set_command(command.clone()))
         .push_input(
             Input::new(
                 "second sensor",
                 1,
-                Some(IOKind::EC),
+                IOKind::EC,
             ).set_command(command.clone()))
         .push_output(
             Output::new(
                 "output device",
                 2,
-                Some(IOKind::Flow)
+                IOKind::Flow
             ).set_command(IOCommand::Output(|_| Ok(())))
         );
 
@@ -52,7 +52,7 @@ fn test_poll() {
             Input::new(
                 "test name",
                 0,
-                Some(IOKind::PH),
+                IOKind::PH,
             ).set_command(
                 command.clone()
             ).init_log(Some(settings.clone()))
@@ -62,7 +62,7 @@ fn test_poll() {
             Input::new(
                 "second sensor",
                 1,
-                Some(IOKind::EC),
+                IOKind::EC,
             ).set_command(
                 command.clone()
             ).init_log(

--- a/tests/grouping_test.rs
+++ b/tests/grouping_test.rs
@@ -55,7 +55,7 @@ fn test_poll() {
                 IOKind::PH,
             ).set_command(
                 command.clone()
-            ).init_log(Some(settings.clone()))
+            ).init_log(settings.clone())
 
         ).push_input(
 
@@ -66,7 +66,7 @@ fn test_poll() {
             ).set_command(
                 command.clone()
             ).init_log(
-                Some(settings.clone())
+                settings.clone()
             )
 
         );


### PR DESCRIPTION
- Simplifies `Device` API by not requiring parameters be wrapped in `Some(_)` for the following:
    * `Device::init_log()`
    * `Device::new()`
- Improves readability by dividing getter/setter methods into traits for `Device`
- Adds setters for `name` and `id` for `Device`
- Improved methods for inserting `Device` for `Group` so as to maintain unique id's